### PR TITLE
BadUpdate upgrade + small improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.rar
 *.7z
 *.tar.gz
+360-hack-pack-v*/

--- a/360hp
+++ b/360hp
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-version=1.0.2
+version=1.0.3
 
 system_update_dl="https://download.digiex.net/Consoles/Xbox360/Dashboards/SystemUpdate_17559_USB.zip"
 system_update="$(basename $system_update_dl .zip)"
 
-bad_update_dl="https://github.com/grimdoomer/Xbox360BadUpdate/releases/download/v1.1/Xbox360BadUpdate-Retail-USB-v1.1.zip"
+bad_update_dl="https://github.com/grimdoomer/Xbox360BadUpdate/releases/download/v1.2/Xbox360BadUpdate-Retail-USB-v1.2.zip"
 bad_update="$(basename $bad_update_dl .zip)"
 
 rock_band_blitz_demo_dl="https://download.digiex.net/Consoles/Xbox360/Arcade-games/RBBlitz.zip"
@@ -61,25 +61,33 @@ if ! command -v 7z &> /dev/null || ! command -v curl &> /dev/null || ! command -
 
         if command -v port > /dev/null; then
             echo "Dependencies for 360 Hack Pack will be installed, which requires root privileges."
-            echo "Using MacPorts"
+            echo "Using MacPorts..."
             sudo port -N install p7zip zip curl
         else
-            echo "Error: MacPorts is not installed meaning 360 Hack Pack can not install the required dependencies automatically."
+            echo "Error: MacPorts is not installed, meaning that 360 Hack Pack can not install the required dependencies automatically."
+            echo "Before running this script, make sure the following tools are installed on your system: 7z, zip, curl"
+            exit 1
         fi
         
-    elif [ "$(shell uname)" = "Linux" ]; then
+    else
         echo "Linux detected."
 
-        if command -v dnf &> /dev/null || command -v apt &> /dev/null; then
+        if command -v pacman &> /dev/null || command -v apt &> /dev/null || command -v dnf &> /dev/null; then
             echo "Dependencies for 360 Hack Pack will be installed, which requires root privileges."
         fi
 
-        if command -v dnf &> /dev/null; then
-            sudo dnf -y install p7zip zip curl
+        if command -v pacman &> /dev/null; then
+            echo "Using pacman..."
+            sudo pacman -Sy --noconfirm 7zip zip curl
         elif command -v apt &> /dev/null; then
+            echo "Using apt..."
             sudo apt install --yes p7zip zip curl
+        elif command -v dnf &> /dev/null; then
+            echo "Using dnf..."
+            sudo dnf -y install p7zip zip curl
         else
-            echo "Error: neither the dnf apt package managers are installed on your system meaning 360 Hack Pack can not install the required dependencies automatically."
+            echo "Error: neither the dnf, apt or pacman package managers are installed on your system, meaning that 360 Hack Pack can not install the required dependencies automatically."
+            echo "Before running this script, make sure the following tools are installed on your system: 7z, zip, curl"
             exit 1
         fi
     fi
@@ -222,7 +230,7 @@ elif [ "$1" == "-x" ]; then
     if [ "$bsd_sed" == "true" ]; then
         sed -i '' -E "s|^Default =.*|Default = Usb:\\\\apps\\\\$aurora\\\\Aurora.xex|" "$2"/launch.ini
     else
-        sed -i'' -E"s|^Default =.*|Default = Usb:\\\\apps\\\\$aurora\\\\Aurora.xex|" "$2"/launch.ini
+        sed -i'' -E "s|^Default =.*|Default = Usb:\\\\apps\\\\$aurora\\\\Aurora.xex|" "$2"/launch.ini
     fi
 
     mkdir -p "$2"/apps/$xell_reloaded

--- a/build
+++ b/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version="1.0.2"
+version=1.0.3
 echo "360 Hack Pack v$version build system"
 
 if sed --version >/dev/null 2>&1; then

--- a/installer
+++ b/installer
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-version=1.0.2
+version=1.0.3
 echo -e "360 Hack Pack v$version\n(C) 2025 Alex Free (3-BSD)\nhttps://github.com/alex-free/360-hack-pack\n"
 
 if [ $# -ne 1 ]; then
-    echo "Error: first argument must be the USB drive you wish to install this to."
+    echo "Error: first argument must be the USB drive you wish to install this to!"
     exit 1
 fi
 

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ _By Alex Free_.
 Everything you need to hack an Xbox 360, ready to be copied onto a USB drive in one download! This currently includes:
 
 * [FreeMyXe](https://github.com/FreeMyXe/FreeMyXe) Beta 5 OR [XeUnshackle](https://github.com/Byrom90/XeUnshackle) v1.0.2 Beta (YOU DECIDE!).
-* [BadUpdate](https://github.com/grimdoomer/Xbox360BadUpdate) v1.1.
+* [BadUpdate](https://github.com/grimdoomer/Xbox360BadUpdate) v1.2.
 * [XexMenu Live](https://digiex.net/threads/xexmenu-1-1-download-xex-menu-iso-live-and-xex-file-manager-for-xbox-360.11096/) v1.1.
 * [Aurora](http://phoenix.xboxunity.net/#/news) v0.7b2.
 * [Simple 360 Nand Flasher](https://github.com/Swizzy/XDK_Projects) v1.5b Read Only (Special BadUpdate Edition).


### PR DESCRIPTION
A few days ago, grimdoomer released the patch version 1.2 of BadUpdate with a significant success rate increase, so I thought it would be nice to add that in this hack pack. Along with it, I also did some small improvements in the build scripts. Full change log bellow:

+ Upgraded BadUpdate to v1.2
+ Added pacman package manager support (for arch linux users)
+ Fixed bug on ```360hp``` script when using ```sed``` command on non-BSD systems
+ ```.gitignore``` now also ignores build folders
+ Hack pack version ID updated to v1.0.3

All is left to do now is to draft a new release and update ```readme.md``` with the updated links and change log.